### PR TITLE
add cf websockets plugin

### DIFF
--- a/basic/durable-object/package.json
+++ b/basic/durable-object/package.json
@@ -41,7 +41,7 @@
     "./package.json": "./package.json"
   },
   "dependencies": {
-    "@cloudflare/workers-types": "^4.20251011.0",
+    "@cloudflare/workers-types": "catalog:core-common",
     "@ground0/shared": "workspace:*",
     "drizzle-query-logger": "^1.1.1",
     "semver": "^7.7.2",

--- a/basic/shared/package.json
+++ b/basic/shared/package.json
@@ -44,6 +44,6 @@
     "@standard-schema/spec": "^1.0.0",
     "zod": "catalog:validators",
     "semver": "^7.7.2",
-    "@cloudflare/workers-types": "^4.20250801.0"
+    "@cloudflare/workers-types": "catalog:core-common"
   }
 }

--- a/extras/vite-plugin-sveltekit-cf-websockets/LICENSE.md
+++ b/extras/vite-plugin-sveltekit-cf-websockets/LICENSE.md
@@ -1,0 +1,39 @@
+# ground0 License (Modified Open Source Software Alliance License)
+
+All of the documentation and software included in ground0 is copyrighted by the ground0 contributors.
+
+Copyright 2026 ground0 contributors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+3. All advertising materials mentioning features or use of this software
+   should, in good faith, display the following acknowledgment:
+   > This product includes software developed by the ground0 contributors.
+4. Redistributions of source code must not be used in conjunction
+   with any software license that requires disclosure of source
+   code (ex: the GNU Public License, hereafter known as the GPL).
+5. Redistributions of source code in any non-textual form (i.e.
+   binary or object form, etc.) must not be linked to software that is
+   released with a license that requires disclosure of source code
+   (ex: the GPL).
+6. Redistributions of source code may be licensed under more than one
+   license, but must not have the terms of the Modified OSSAL removed.
+
+THIS SOFTWARE IS PROVIDED BY THE GROUND0 CONTRIBUTORS 'AS IS' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE GROUND0 CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/extras/vite-plugin-sveltekit-cf-websockets/README.md
+++ b/extras/vite-plugin-sveltekit-cf-websockets/README.md
@@ -1,0 +1,38 @@
+# vite-plugin-sveltekit-cf-websockets
+
+> [!CAUTION]
+> This plugin was written fully by Claude Code. Expect that it might break or
+> behave in unexpected ways if you have an unusual SvelteKit setup, or if your
+> routes do something that it did not predict, or if today is a Tuesday.
+>
+> This is not at all helped by the fact that the plugin touches SvelteKit
+> internals. It can equally break because of an update to SvelteKit.
+
+A Vite plugin to fix WebSocket upgrades in the dev server with SvelteKit when
+targeting Cloudflare Workers. Made to be used with
+[ground0](https://github.com/rizz-zone/ground0), but you may find that it works
+well enough for other use cases as well.
+
+## Usage
+
+Simply add the plugin to your Vite config.
+
+```ts
+import { sveltekit } from '@sveltejs/kit/vite'
+import svelteKitWebSockets from 'vite-plugin-sveltekit-cf-websockets'
+
+export default defineConfig({
+	plugins: [svelteKitWebSockets(), sveltekit()]
+})
+```
+
+You can pass a `verbose` option to the plugin to get more detailed logging.
+
+```ts
+import { sveltekit } from '@sveltejs/kit/vite'
+import svelteKitWebSockets from 'vite-plugin-sveltekit-cf-websockets'
+
+export default defineConfig({
+	plugins: [svelteKitWebSockets({ verbose: true }), sveltekit()]
+})
+```

--- a/extras/vite-plugin-sveltekit-cf-websockets/package.json
+++ b/extras/vite-plugin-sveltekit-cf-websockets/package.json
@@ -31,7 +31,7 @@
 		"ws": "^8.18.0"
 	},
 	"devDependencies": {
-		"@cloudflare/workers-types": "^4.20260120.0",
+		"@cloudflare/workers-types": "catalog:core-common",
 		"@types/ws": "^8.18.0"
 	},
 	"peerDependencies": {

--- a/extras/vite-plugin-sveltekit-cf-websockets/package.json
+++ b/extras/vite-plugin-sveltekit-cf-websockets/package.json
@@ -1,0 +1,42 @@
+{
+	"name": "vite-plugin-sveltekit-cf-websockets",
+	"version": "0.1.0",
+	"license": "SEE LICENSE IN LICENSE.md",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/rizz-zone/ground0",
+		"directory": "extras/vite-plugin-sveltekit-cf-websockets"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"private": false,
+	"sideEffects": false,
+	"packageManager": "pnpm@10.18.3",
+	"type": "module",
+	"scripts": {
+		"build": "tsdown",
+		"dev": "tsdown --watch --no-clean",
+		"check-types": "tsc",
+		"lint": "eslint ."
+	},
+	"main": "./dist/index.js",
+	"module": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": "./dist/index.js",
+		"./package.json": "./package.json"
+	},
+	"dependencies": {
+		"ws": "^8.18.0"
+	},
+	"devDependencies": {
+		"@cloudflare/workers-types": "^4.20260120.0",
+		"@types/ws": "^8.18.0"
+	},
+	"peerDependencies": {
+		"@sveltejs/kit": "^2.0.0",
+		"typescript": "^5.8.3",
+		"vite": "^5.0.0 || ^6.0.0 || ^7.0.0"
+	}
+}

--- a/extras/vite-plugin-sveltekit-cf-websockets/src/index.ts
+++ b/extras/vite-plugin-sveltekit-cf-websockets/src/index.ts
@@ -1,0 +1,687 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { createRequire } from 'node:module'
+import { pathToFileURL } from 'node:url'
+import { loadEnv, type Plugin, type ViteDevServer } from 'vite'
+import type { IncomingMessage } from 'node:http'
+import type { Duplex } from 'node:stream'
+import { getRequest } from '@sveltejs/kit/node'
+import { WebSocketServer, type WebSocket as NodeWebSocket } from 'ws'
+
+// --- Type Definitions ---
+
+interface Asset {
+	file: string
+	type?: string
+}
+
+interface RouteParam {
+	name: string
+	matcher?: string
+	optional: boolean
+	rest: boolean
+	chained: boolean
+}
+
+interface PageNode {
+	depth: number
+	component?: string
+	universal?: string
+	server?: string
+}
+
+interface RouteEndpoint {
+	file: string
+}
+
+interface PageDefinition {
+	layouts: (number | undefined)[]
+	errors: (number | undefined)[]
+	leaf: number
+}
+
+interface RouteData {
+	id: string
+	pattern: RegExp
+	params: RouteParam[]
+	page: PageDefinition | null
+	endpoint: RouteEndpoint | null
+}
+
+interface ManifestData {
+	assets: Asset[]
+	nodes: PageNode[]
+	routes: RouteData[]
+	matchers: Record<string, string>
+}
+
+interface SvelteKitConfig {
+	kit: {
+		appDir: string
+		outDir: string
+		paths: {
+			base: string
+			assets: string
+		}
+		files: {
+			routes: string
+			params: string
+			assets: string
+			hooks: {
+				client: string
+				server: string
+				universal: string
+			}
+		}
+		env: {
+			dir: string
+		}
+		moduleExtensions: string[]
+		adapter?: {
+			emulate?: () => Promise<Emulator>
+		}
+	}
+}
+
+interface Emulator {
+	platform?: (details: {
+		config: SvelteKitConfig
+		prerender?: boolean
+	}) => Promise<App.Platform>
+}
+
+interface SSRNode {
+	index: number
+	universal_id?: string
+	server_id?: string
+	component?: () => Promise<unknown>
+	universal?: unknown
+	server?: unknown
+	imports: string[]
+	stylesheets: string[]
+	fonts: string[]
+	inline_styles?: () => Promise<Record<string, string>>
+}
+
+interface SSRRoute {
+	id: string
+	pattern: RegExp
+	params: RouteParam[]
+	page: PageDefinition | null
+	endpoint: (() => Promise<unknown>) | null
+	endpoint_id?: string
+}
+
+interface SSRManifest {
+	appDir: string
+	appPath: string
+	assets: Set<string>
+	mimeTypes: Record<string, string>
+	_: {
+		client: {
+			start: string
+			app: string
+			imports: string[]
+			stylesheets: string[]
+			fonts: string[]
+			uses_env_dynamic_public: boolean
+		}
+		server_assets: Record<string, number>
+		nodes: Array<() => Promise<SSRNode>>
+		prerendered_routes: Set<string>
+		remotes: Record<string, unknown>
+		routes: SSRRoute[]
+		matchers: () => Promise<Record<string, (param: string) => boolean>>
+	}
+}
+
+interface CloudflareWebSocket {
+	accept(): void
+	send(data: string | ArrayBuffer): void
+	close(code?: number, reason?: string): void
+	addEventListener(
+		type: 'message',
+		listener: (event: { data: string | ArrayBuffer }) => void
+	): void
+	addEventListener(
+		type: 'close',
+		listener: (event: { code: number; reason: string }) => void
+	): void
+	addEventListener(type: 'error', listener: (event: unknown) => void): void
+}
+
+// Use intersection type to avoid extending Response (which has webSocket?: WebSocket | null)
+type CloudflareWebSocketResponse = Response & {
+	webSocket?: CloudflareWebSocket
+}
+
+// --- Utilities (inlined from SvelteKit internals) ---
+
+function posixify(str: string): string {
+	return str.replace(/\\/g, '/')
+}
+
+function toFs(str: string): string {
+	str = posixify(str)
+	return `/@fs${str.startsWith('/') ? '' : '/'}${str}`
+}
+
+function fromFs(str: string): string {
+	str = posixify(str)
+	if (!str.startsWith('/@fs')) return str
+	str = str.slice(4)
+	return str[2] === ':' && /[A-Z]/.test(str[1]) ? str.slice(1) : str
+}
+
+function compact<T>(arr: (T | null | undefined)[]): NonNullable<T>[] {
+	return arr.filter((val): val is NonNullable<T> => val != null)
+}
+
+function getMimeLookup(manifestData: ManifestData): Record<string, string> {
+	const mime: Record<string, string> = {}
+	for (const asset of manifestData.assets) {
+		if (asset.type) {
+			mime[path.extname(asset.file)] = asset.type
+		}
+	}
+	return mime
+}
+
+// --- SSR Manifest Construction ---
+
+function buildSSRManifest(
+	manifestData: ManifestData,
+	config: SvelteKitConfig,
+	vite: ViteDevServer,
+	runtimeBase: string
+): SSRManifest {
+	const cwd = process.cwd()
+
+	function resolveModuleUrl(id: string): string {
+		return id.startsWith('..') ? toFs(path.posix.resolve(id)) : `/${id}`
+	}
+
+	return {
+		appDir: config.kit.appDir,
+		appPath: config.kit.appDir,
+		assets: new Set(manifestData.assets.map((a) => a.file)),
+		mimeTypes: getMimeLookup(manifestData),
+		_: {
+			client: {
+				start: `${runtimeBase}/client/entry.js`,
+				app: `${toFs(config.kit.outDir)}/generated/client/app.js`,
+				imports: [],
+				stylesheets: [],
+				fonts: [],
+				uses_env_dynamic_public: true
+			},
+			server_assets: new Proxy(
+				{},
+				{
+					has: (_target, file: string) => {
+						try {
+							return fs.existsSync(fromFs(file))
+						} catch {
+							return false
+						}
+					},
+					get: (_target, file: string) => {
+						try {
+							return fs.statSync(fromFs(file)).size
+						} catch {
+							return undefined
+						}
+					}
+				}
+			),
+			nodes: manifestData.nodes.map((node, index) => {
+				return async (): Promise<SSRNode> => {
+					const result: SSRNode = {
+						index,
+						universal_id: node.universal,
+						server_id: node.server,
+						imports: [],
+						stylesheets: [],
+						fonts: []
+					}
+
+					if (node.component) {
+						result.component = async () => {
+							const url = resolveModuleUrl(node.component as string)
+							const mod = await vite.ssrLoadModule(url, {
+								fixStacktrace: true
+							})
+							return mod.default
+						}
+					}
+
+					if (node.universal) {
+						const url = resolveModuleUrl(node.universal)
+						const mod = await vite.ssrLoadModule(url, {
+							fixStacktrace: true
+						})
+						result.universal = mod
+					}
+
+					if (node.server) {
+						const url = resolveModuleUrl(node.server)
+						const mod = await vite.ssrLoadModule(url, {
+							fixStacktrace: true
+						})
+						result.server = mod
+					}
+
+					result.inline_styles = async () => ({})
+					return result
+				}
+			}),
+			prerendered_routes: new Set(),
+			remotes: {},
+			routes: compact(
+				manifestData.routes.map((route): SSRRoute | null => {
+					if (!route.page && !route.endpoint) return null
+
+					const endpoint = route.endpoint
+
+					return {
+						id: route.id,
+						pattern: route.pattern,
+						params: route.params,
+						page: route.page,
+						endpoint: endpoint
+							? async () => {
+									const url = path.resolve(cwd, endpoint.file)
+									return await vite.ssrLoadModule(url, {
+										fixStacktrace: true
+									})
+								}
+							: null,
+						endpoint_id: endpoint?.file
+					}
+				})
+			),
+			matchers: async () => {
+				const matchers: Record<string, (param: string) => boolean> = {}
+				for (const key in manifestData.matchers) {
+					const file = manifestData.matchers[key]
+					const url = path.resolve(cwd, file)
+					const mod = await vite.ssrLoadModule(url, {
+						fixStacktrace: true
+					})
+					if (mod.match) {
+						matchers[key] = mod.match
+					}
+				}
+				return matchers
+			}
+		}
+	}
+}
+
+// --- File Watching ---
+
+function setupManifestWatching(
+	vite: ViteDevServer,
+	config: SvelteKitConfig,
+	onUpdate: () => void
+): void {
+	let timeout: ReturnType<typeof setTimeout> | null = null
+
+	const debounce = (fn: () => void) => {
+		if (timeout) clearTimeout(timeout)
+		timeout = setTimeout(() => {
+			timeout = null
+			fn()
+		}, 100)
+	}
+
+	const isWatched = (file: string): boolean => {
+		return (
+			file.startsWith(config.kit.files.routes + path.sep) ||
+			file.startsWith(config.kit.files.params + path.sep) ||
+			file.startsWith(config.kit.files.hooks.client) ||
+			(config.kit.moduleExtensions || []).some((ext: string) =>
+				file.endsWith(`.remote${ext}`)
+			)
+		)
+	}
+
+	vite.watcher.on('add', (file: string) => {
+		if (isWatched(file)) debounce(onUpdate)
+	})
+
+	vite.watcher.on('unlink', (file: string) => {
+		if (isWatched(file)) debounce(onUpdate)
+	})
+}
+
+// --- WebSocket Upgrade Handler ---
+
+interface UpgradeContext {
+	getManifest: () => SSRManifest
+	runtimeBase: string
+	env: Record<string, string>
+	emulator: Emulator | undefined
+	verbose: boolean
+}
+
+function setupUpgradeHandler(
+	vite: ViteDevServer,
+	svelteConfig: SvelteKitConfig,
+	ctx: UpgradeContext
+): void {
+	const httpServer = vite.httpServer
+	if (!httpServer) return
+
+	const log = (...args: unknown[]) => ctx.verbose && console.log(...args)
+	const error = (...args: unknown[]) => ctx.verbose && console.error(...args)
+
+	httpServer.on(
+		'upgrade',
+		async (req: IncomingMessage, _socket: Duplex, _head: Buffer) => {
+			// Skip Vite's own HMR WebSocket upgrades
+			const protocol = req.headers['sec-websocket-protocol']
+			if (
+				typeof protocol === 'string' &&
+				protocol
+					.split(',')
+					.map((p) => p.trim())
+					.includes('vite-hmr')
+			) {
+				return
+			}
+
+			log(`[sveltekit-ws] Intercepted upgrade request: ${req.url}`)
+
+			try {
+				const base = `${vite.config.server.https ? 'https' : 'http'}://${
+					req.headers[':authority'] || req.headers.host
+				}`
+
+				// Convert Node.js IncomingMessage to Web API Request
+				const request = await getRequest({ base, request: req })
+
+				const manifest = ctx.getManifest()
+				const url = new URL(request.url)
+
+				// Find matching route
+				const route = manifest._.routes.find((r) =>
+					r.pattern.test(url.pathname)
+				)
+				if (!route || !route.endpoint) {
+					error('[sveltekit-ws] No matching WebSocket endpoint found')
+					return
+				}
+
+				// Load endpoint module directly via Vite SSR (bypasses SvelteKit response validation)
+				const endpointModule = (await route.endpoint()) as {
+					GET?: (event: unknown) => Promise<Response>
+				}
+				if (!endpointModule.GET) {
+					error('[sveltekit-ws] Endpoint has no GET handler')
+					return
+				}
+
+				// Get platform from emulator
+				let platform: App.Platform | undefined
+				if (ctx.emulator?.platform) {
+					platform = await ctx.emulator.platform({
+						config: svelteConfig,
+						prerender: false
+					})
+				}
+
+				// Call the endpoint directly, bypassing SvelteKit's response validation
+				// This allows Miniflare's _Response (with webSocket property) to pass through
+				const response = await endpointModule.GET({
+					request,
+					platform,
+					url,
+					params: {},
+					locals: {},
+					cookies: {
+						get: () => undefined,
+						getAll: () => [],
+						set: () => {},
+						delete: () => {},
+						serialize: () => ''
+					},
+					getClientAddress: () => {
+						const { remoteAddress } = req.socket
+						if (remoteAddress) return remoteAddress
+						throw new Error('Could not determine clientAddress')
+					},
+					isDataRequest: false,
+					isSubRequest: false,
+					fetch: globalThis.fetch,
+					setHeaders: () => {},
+					depends: () => {},
+					untrack: (fn: () => unknown) => fn()
+				})
+
+				const cfResponse = response as CloudflareWebSocketResponse
+
+				// Check if this is a WebSocket upgrade response
+				if (cfResponse.status === 101 && cfResponse.webSocket) {
+					log('[sveltekit-ws] Got WebSocket upgrade, establishing bridge...')
+
+					const cfWebSocket = cfResponse.webSocket
+
+					// Create a WebSocketServer to handle the Node.js side
+					const wss = new WebSocketServer({ noServer: true })
+
+					// Handle the upgrade using ws library
+					wss.handleUpgrade(req, _socket, _head, (nodeWs: NodeWebSocket) => {
+						log('[sveltekit-ws] Node.js WebSocket connected')
+
+						// Accept the Cloudflare WebSocket
+						cfWebSocket.accept()
+						log('[sveltekit-ws] Cloudflare WebSocket accepted')
+
+						// Bridge: Node.js client -> Cloudflare WebSocket
+						nodeWs.on('message', (data: Buffer | string) => {
+							try {
+								const message =
+									typeof data === 'string' ? data : data.toString()
+								cfWebSocket.send(message)
+							} catch (err) {
+								error('[sveltekit-ws] Error forwarding to CF:', err)
+							}
+						})
+
+						// Bridge: Cloudflare WebSocket -> Node.js client
+						cfWebSocket.addEventListener('message', (event) => {
+							try {
+								if (nodeWs.readyState === nodeWs.OPEN) {
+									nodeWs.send(event.data)
+								}
+							} catch (err) {
+								error('[sveltekit-ws] Error forwarding to client:', err)
+							}
+						})
+
+						// Handle close from Node.js client
+						nodeWs.on('close', (code: number, reason: Buffer) => {
+							log(`[sveltekit-ws] Node.js client closed: ${code}`)
+							try {
+								cfWebSocket.close(code, reason.toString())
+							} catch {
+								// Already closed
+							}
+						})
+
+						// Handle close from Cloudflare WebSocket
+						cfWebSocket.addEventListener('close', (event) => {
+							log(
+								`[sveltekit-ws] Cloudflare WebSocket closed: ${event.code}`
+							)
+							try {
+								if (nodeWs.readyState === nodeWs.OPEN) {
+									nodeWs.close(event.code, event.reason)
+								}
+							} catch {
+								// Already closed
+							}
+						})
+
+						// Handle errors
+						nodeWs.on('error', (err: Error) => {
+							error('[sveltekit-ws] Node.js WebSocket error:', err)
+							try {
+								cfWebSocket.close(1011, 'Internal error')
+							} catch {
+								// Already closed
+							}
+						})
+
+						cfWebSocket.addEventListener('error', (event) => {
+							error('[sveltekit-ws] Cloudflare WebSocket error:', event)
+							try {
+								nodeWs.close(1011, 'Internal error')
+							} catch {
+								// Already closed
+							}
+						})
+
+						log('[sveltekit-ws] WebSocket bridge established')
+					})
+				} else {
+					// Not a WebSocket upgrade, log error
+					error('[sveltekit-ws] Expected WebSocket upgrade but got:', {
+						status: cfResponse.status,
+						hasWebSocket: 'webSocket' in cfResponse
+					})
+					_socket.destroy()
+				}
+			} catch (err) {
+				error('[sveltekit-ws] WebSocket upgrade error:', err)
+			}
+		}
+	)
+}
+
+// --- Main Plugin ---
+
+export interface PluginOptions {
+	verbose?: boolean
+}
+
+/**
+ * Vite plugin that intercepts WebSocket upgrade requests and routes them
+ * through SvelteKit's request handling pipeline, preserving the Response
+ * object (including any `webSocket` property from Cloudflare-style handlers).
+ */
+export function svelteKitWebSockets(options: PluginOptions = {}): Plugin {
+	const { verbose = false } = options
+
+	return {
+		name: 'sveltekit-websockets',
+
+		async configureServer(vite) {
+			const log = (...args: unknown[]) => verbose && console.log(...args)
+			const warn = (...args: unknown[]) => verbose && console.warn(...args)
+			const error = (...args: unknown[]) => verbose && console.error(...args)
+
+			if (!vite.httpServer) {
+				warn(
+					'[sveltekit-ws] No HTTP server available, skipping WebSocket setup'
+				)
+				return
+			}
+
+			// Block WebSocket upgrade requests from going through SvelteKit's middleware
+			vite.middlewares.use((req, _res, next) => {
+				if (req.headers['upgrade']?.toLowerCase() === 'websocket') {
+					// Don't call next() - the upgrade event handler will process this
+					return
+				}
+				next()
+			})
+
+			// Resolve the @sveltejs/kit package root
+			const _require = createRequire(import.meta.url)
+			const kitRoot = path.dirname(
+				_require.resolve('@sveltejs/kit/package.json')
+			)
+
+			// Dynamic import helper for SvelteKit internal modules
+			const impKit = (subpath: string) =>
+				import(pathToFileURL(path.join(kitRoot, subpath)).href)
+
+			// Import internal SvelteKit modules
+			const [configMod, createManifestDataMod] = await Promise.all([
+				impKit('src/core/config/index.js'),
+				impKit('src/core/sync/create_manifest_data/index.js')
+			])
+
+			const loadConfig = configMod.load_config as (opts?: {
+				cwd?: string
+			}) => Promise<SvelteKitConfig>
+			const createManifestData = createManifestDataMod.default as (opts: {
+				config: SvelteKitConfig
+			}) => ManifestData
+
+			// Compute the runtime base path
+			const runtimeDir = posixify(path.join(kitRoot, 'src/runtime'))
+			const runtimeBase = runtimeDir.startsWith(process.cwd())
+				? `/${path.relative('.', runtimeDir)}`
+				: toFs(runtimeDir)
+
+			// Load the SvelteKit config
+			const svelteConfig = await loadConfig()
+
+			// Load environment variables
+			const env = loadEnv(vite.config.mode, svelteConfig.kit.env.dir, '')
+
+			// Try to get the adapter emulator
+			let emulator: Emulator | undefined = undefined
+			try {
+				emulator = await svelteConfig.kit.adapter?.emulate?.()
+			} catch (err) {
+				warn('[sveltekit-ws] Adapter emulator not available:', err)
+			}
+
+			// Build the initial manifest
+			let manifestData: ManifestData
+			let manifest: SSRManifest
+
+			const rebuildManifest = () => {
+				manifestData = createManifestData({ config: svelteConfig })
+				manifest = buildSSRManifest(
+					manifestData,
+					svelteConfig,
+					vite,
+					runtimeBase
+				)
+			}
+
+			try {
+				rebuildManifest()
+				log('[sveltekit-ws] Initial manifest built')
+			} catch (err) {
+				error('[sveltekit-ws] Initial manifest error:', err)
+			}
+
+			// Watch for route file changes
+			setupManifestWatching(vite, svelteConfig, () => {
+				try {
+					rebuildManifest()
+					log('[sveltekit-ws] Manifest updated')
+				} catch (err) {
+					error('[sveltekit-ws] Manifest update error:', err)
+				}
+			})
+
+			// Register the WebSocket upgrade handler
+			setupUpgradeHandler(vite, svelteConfig, {
+				getManifest: () => manifest,
+				runtimeBase,
+				env,
+				emulator,
+				verbose
+			})
+
+			log('[sveltekit-ws] WebSocket upgrade handler registered')
+		}
+	}
+}

--- a/extras/vite-plugin-sveltekit-cf-websockets/src/index.ts
+++ b/extras/vite-plugin-sveltekit-cf-websockets/src/index.ts
@@ -512,9 +512,7 @@ function setupUpgradeHandler(
 
 						// Handle close from Cloudflare WebSocket
 						cfWebSocket.addEventListener('close', (event) => {
-							log(
-								`[sveltekit-ws] Cloudflare WebSocket closed: ${event.code}`
-							)
+							log(`[sveltekit-ws] Cloudflare WebSocket closed: ${event.code}`)
 							try {
 								if (nodeWs.readyState === nodeWs.OPEN) {
 									nodeWs.close(event.code, event.reason)

--- a/extras/vite-plugin-sveltekit-cf-websockets/tsconfig.json
+++ b/extras/vite-plugin-sveltekit-cf-websockets/tsconfig.json
@@ -1,0 +1,12 @@
+{
+	"compilerOptions": {
+		"target": "ESNext",
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"strict": true,
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"outDir": "./dist"
+	},
+	"include": ["src"]
+}

--- a/extras/vite-plugin-sveltekit-cf-websockets/tsdown.config.ts
+++ b/extras/vite-plugin-sveltekit-cf-websockets/tsdown.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+	exports: true,
+	dts: true,
+	unbundle: true,
+	target: 'esnext',
+	platform: 'neutral',
+	sourcemap: true,
+	entry: {
+		index: 'src/index.ts'
+	}
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,7 +100,7 @@ importers:
         version: link:../shared
       drizzle-orm:
         specifier: catalog:core-common
-        version: 0.44.7(@cloudflare/workers-types@4.20260116.0)(bun-types@1.3.6)
+        version: 0.44.7(@cloudflare/workers-types@4.20260129.0)(bun-types@1.3.6)
       superjson:
         specifier: catalog:core-common
         version: 2.2.6
@@ -177,7 +177,7 @@ importers:
         version: link:../shared
       drizzle-orm:
         specifier: catalog:core-common
-        version: 0.44.7(@cloudflare/workers-types@4.20260116.0)(bun-types@1.3.6)
+        version: 0.44.7(@cloudflare/workers-types@4.20260129.0)(bun-types@1.3.6)
       typescript:
         specifier: ^5.8.3
         version: 5.9.3
@@ -225,6 +225,28 @@ importers:
         specifier: ^5.8.3
         version: 5.9.3
 
+  extras/vite-plugin-sveltekit-cf-websockets:
+    dependencies:
+      '@sveltejs/kit':
+        specifier: ^2.0.0
+        version: 2.49.5(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.46.4)(vite@7.3.1(@types/node@25.0.9)(jiti@2.6.1)))(svelte@5.46.4)(typescript@5.9.3)(vite@7.3.1(@types/node@25.0.9)(jiti@2.6.1))
+      typescript:
+        specifier: ^5.8.3
+        version: 5.9.3
+      vite:
+        specifier: ^5.0.0 || ^6.0.0 || ^7.0.0
+        version: 7.3.1(@types/node@25.0.9)(jiti@2.6.1)
+      ws:
+        specifier: ^8.18.0
+        version: 8.19.0
+    devDependencies:
+      '@cloudflare/workers-types':
+        specifier: ^4.20260120.0
+        version: 4.20260129.0
+      '@types/ws':
+        specifier: ^8.18.0
+        version: 8.18.1
+
   sample_integrations/counter/_durable-object:
     dependencies:
       '@ground0/sample-counter-shared':
@@ -232,7 +254,7 @@ importers:
         version: link:../_shared
       drizzle-orm:
         specifier: catalog:core-common
-        version: 0.44.7(@cloudflare/workers-types@4.20260116.0)(bun-types@1.3.6)
+        version: 0.44.7(@cloudflare/workers-types@4.20260129.0)(bun-types@1.3.6)
       ground0:
         specifier: workspace:*
         version: link:../../../basic/ground0
@@ -254,13 +276,13 @@ importers:
         version: 3.2.4(@types/node@25.0.9)(jiti@2.6.1)(jsdom@26.1.0)(msw@2.12.7(@types/node@25.0.9)(typescript@5.9.3))
       wrangler:
         specifier: ^4.46.0
-        version: 4.59.2(@cloudflare/workers-types@4.20260116.0)
+        version: 4.59.2(@cloudflare/workers-types@4.20260129.0)
 
   sample_integrations/counter/_shared:
     dependencies:
       drizzle-orm:
         specifier: catalog:core-common
-        version: 0.44.7(@cloudflare/workers-types@4.20260116.0)(bun-types@1.3.6)
+        version: 0.44.7(@cloudflare/workers-types@4.20260129.0)(bun-types@1.3.6)
       ground0:
         specifier: workspace:*
         version: link:../../../basic/ground0
@@ -285,7 +307,7 @@ importers:
         version: link:../../../adapters/sveltekit
       drizzle-orm:
         specifier: catalog:core-common
-        version: 0.44.7(@cloudflare/workers-types@4.20260116.0)(bun-types@1.3.6)
+        version: 0.44.7(@cloudflare/workers-types@4.20260129.0)(bun-types@1.3.6)
       ground0:
         specifier: workspace:*
         version: link:../../../basic/ground0
@@ -576,6 +598,9 @@ packages:
 
   '@cloudflare/workers-types@4.20260116.0':
     resolution: {integrity: sha512-iMZIQDco7ARzzH+r8j90757kbPKEetKY3/6V5UurOzS6T1GJ+rsREw5i7vlBA4XjFV5UMaPtUD6HuUFSMLcxPQ==}
+
+  '@cloudflare/workers-types@4.20260129.0':
+    resolution: {integrity: sha512-ytqtGV7L60HI/BL/p6tY1A5DIIlNl0NX+wiNeGTyB6e65x1HEeZrceVzL5RsVws7xMsBpF+2VAlm/3ga3c7Txg==}
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -2144,6 +2169,9 @@ packages:
 
   '@types/statuses@2.0.6':
     resolution: {integrity: sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@typescript-eslint/eslint-plugin@8.53.0':
     resolution: {integrity: sha512-eEXsVvLPu8Z4PkFibtuFJLJOTAV/nPdgtSjkGoPpddpFk3/ym2oy97jynY6ic2m6+nc5M8SE1e9v/mHKsulcJg==}
@@ -4361,6 +4389,8 @@ snapshots:
 
   '@cloudflare/workers-types@4.20260116.0': {}
 
+  '@cloudflare/workers-types@4.20260129.0': {}
+
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
@@ -5413,6 +5443,10 @@ snapshots:
 
   '@types/statuses@2.0.6': {}
 
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 25.0.9
+
   '@typescript-eslint/eslint-plugin@8.53.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
@@ -5822,6 +5856,11 @@ snapshots:
   drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260116.0)(bun-types@1.3.6):
     optionalDependencies:
       '@cloudflare/workers-types': 4.20260116.0
+      bun-types: 1.3.6
+
+  drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260129.0)(bun-types@1.3.6):
+    optionalDependencies:
+      '@cloudflare/workers-types': 4.20260129.0
       bun-types: 1.3.6
 
   drizzle-query-logger@1.1.2(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260116.0)(bun-types@1.3.6))(typescript@5.9.3):
@@ -7287,7 +7326,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  wrangler@4.59.2(@cloudflare/workers-types@4.20260116.0):
+  wrangler@4.59.2(@cloudflare/workers-types@4.20260129.0):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.4.2
       '@cloudflare/unenv-preset': 2.10.0(unenv@2.0.0-rc.24)(workerd@1.20260114.0)
@@ -7298,7 +7337,7 @@ snapshots:
       unenv: 2.0.0-rc.24
       workerd: 1.20260114.0
     optionalDependencies:
-      '@cloudflare/workers-types': 4.20260116.0
+      '@cloudflare/workers-types': 4.20260129.0
       fsevents: 2.3.3
     transitivePeerDependencies:
       - bufferutil

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,9 @@ settings:
 
 catalogs:
   core-common:
+    '@cloudflare/workers-types':
+      specifier: ^4.20260129.0
+      version: 4.20260129.0
     drizzle-orm:
       specifier: ^0.44.6
       version: 0.44.7
@@ -130,17 +133,17 @@ importers:
   basic/durable-object:
     dependencies:
       '@cloudflare/workers-types':
-        specifier: ^4.20251011.0
-        version: 4.20260116.0
+        specifier: catalog:core-common
+        version: 4.20260129.0
       '@ground0/shared':
         specifier: workspace:*
         version: link:../shared
       drizzle-orm:
         specifier: catalog:core-common
-        version: 0.44.7(@cloudflare/workers-types@4.20260116.0)(bun-types@1.3.6)
+        version: 0.44.7(@cloudflare/workers-types@4.20260129.0)(bun-types@1.3.6)
       drizzle-query-logger:
         specifier: ^1.1.1
-        version: 1.1.2(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260116.0)(bun-types@1.3.6))(typescript@5.9.3)
+        version: 1.1.2(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260129.0)(bun-types@1.3.6))(typescript@5.9.3)
       semver:
         specifier: ^7.7.2
         version: 7.7.3
@@ -153,7 +156,7 @@ importers:
     devDependencies:
       '@cloudflare/vitest-pool-workers':
         specifier: ^0.9.13
-        version: 0.9.14(@cloudflare/workers-types@4.20260116.0)(@vitest/runner@3.2.4)(@vitest/snapshot@3.2.4)(vitest@3.2.4(@types/node@25.0.9)(jiti@2.6.1)(jsdom@26.1.0)(msw@2.12.7(@types/node@25.0.9)(typescript@5.9.3)))
+        version: 0.9.14(@cloudflare/workers-types@4.20260129.0)(@vitest/runner@3.2.4)(@vitest/snapshot@3.2.4)(vitest@3.2.4(@types/node@25.0.9)(jiti@2.6.1)(jsdom@26.1.0)(msw@2.12.7(@types/node@25.0.9)(typescript@5.9.3)))
       '@standard-schema/spec':
         specifier: ^1.0.0
         version: 1.1.0
@@ -185,14 +188,14 @@ importers:
   basic/shared:
     dependencies:
       '@cloudflare/workers-types':
-        specifier: ^4.20250801.0
-        version: 4.20260116.0
+        specifier: catalog:core-common
+        version: 4.20260129.0
       '@standard-schema/spec':
         specifier: ^1.0.0
         version: 1.1.0
       drizzle-orm:
         specifier: catalog:core-common
-        version: 0.44.7(@cloudflare/workers-types@4.20260116.0)(bun-types@1.3.6)
+        version: 0.44.7(@cloudflare/workers-types@4.20260129.0)(bun-types@1.3.6)
       semver:
         specifier: ^7.7.2
         version: 7.7.3
@@ -241,7 +244,7 @@ importers:
         version: 8.19.0
     devDependencies:
       '@cloudflare/workers-types':
-        specifier: ^4.20260120.0
+        specifier: catalog:core-common
         version: 4.20260129.0
       '@types/ws':
         specifier: ^8.18.0
@@ -595,9 +598,6 @@ packages:
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
-
-  '@cloudflare/workers-types@4.20260116.0':
-    resolution: {integrity: sha512-iMZIQDco7ARzzH+r8j90757kbPKEetKY3/6V5UurOzS6T1GJ+rsREw5i7vlBA4XjFV5UMaPtUD6HuUFSMLcxPQ==}
 
   '@cloudflare/workers-types@4.20260129.0':
     resolution: {integrity: sha512-ytqtGV7L60HI/BL/p6tY1A5DIIlNl0NX+wiNeGTyB6e65x1HEeZrceVzL5RsVws7xMsBpF+2VAlm/3ga3c7Txg==}
@@ -4340,7 +4340,7 @@ snapshots:
     optionalDependencies:
       workerd: 1.20251011.0
 
-  '@cloudflare/vitest-pool-workers@0.9.14(@cloudflare/workers-types@4.20260116.0)(@vitest/runner@3.2.4)(@vitest/snapshot@3.2.4)(vitest@3.2.4(@types/node@25.0.9)(jiti@2.6.1)(jsdom@26.1.0)(msw@2.12.7(@types/node@25.0.9)(typescript@5.9.3)))':
+  '@cloudflare/vitest-pool-workers@0.9.14(@cloudflare/workers-types@4.20260129.0)(@vitest/runner@3.2.4)(@vitest/snapshot@3.2.4)(vitest@3.2.4(@types/node@25.0.9)(jiti@2.6.1)(jsdom@26.1.0)(msw@2.12.7(@types/node@25.0.9)(typescript@5.9.3)))':
     dependencies:
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -4350,7 +4350,7 @@ snapshots:
       miniflare: 4.20251011.0
       semver: 7.7.3
       vitest: 3.2.4(@types/node@25.0.9)(jiti@2.6.1)(jsdom@26.1.0)(msw@2.12.7(@types/node@25.0.9)(typescript@5.9.3))
-      wrangler: 4.44.0(@cloudflare/workers-types@4.20260116.0)
+      wrangler: 4.44.0(@cloudflare/workers-types@4.20260129.0)
       zod: 3.25.76
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
@@ -4386,8 +4386,6 @@ snapshots:
 
   '@cloudflare/workerd-windows-64@1.20260114.0':
     optional: true
-
-  '@cloudflare/workers-types@4.20260116.0': {}
 
   '@cloudflare/workers-types@4.20260129.0': {}
 
@@ -5853,20 +5851,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260116.0)(bun-types@1.3.6):
-    optionalDependencies:
-      '@cloudflare/workers-types': 4.20260116.0
-      bun-types: 1.3.6
-
   drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260129.0)(bun-types@1.3.6):
     optionalDependencies:
       '@cloudflare/workers-types': 4.20260129.0
       bun-types: 1.3.6
 
-  drizzle-query-logger@1.1.2(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260116.0)(bun-types@1.3.6))(typescript@5.9.3):
+  drizzle-query-logger@1.1.2(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260129.0)(bun-types@1.3.6))(typescript@5.9.3):
     dependencies:
       '@sqltools/formatter': 1.2.5
-      drizzle-orm: 0.44.7(@cloudflare/workers-types@4.20260116.0)(bun-types@1.3.6)
+      drizzle-orm: 0.44.7(@cloudflare/workers-types@4.20260129.0)(bun-types@1.3.6)
       typescript: 5.9.3
 
   dts-resolver@2.1.3: {}
@@ -7309,7 +7302,7 @@ snapshots:
       '@cloudflare/workerd-linux-arm64': 1.20260114.0
       '@cloudflare/workerd-windows-64': 1.20260114.0
 
-  wrangler@4.44.0(@cloudflare/workers-types@4.20260116.0):
+  wrangler@4.44.0(@cloudflare/workers-types@4.20260129.0):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.4.0
       '@cloudflare/unenv-preset': 2.7.8(unenv@2.0.0-rc.21)(workerd@1.20251011.0)
@@ -7320,7 +7313,7 @@ snapshots:
       unenv: 2.0.0-rc.21
       workerd: 1.20251011.0
     optionalDependencies:
-      '@cloudflare/workers-types': 4.20260116.0
+      '@cloudflare/workers-types': 4.20260129.0
       fsevents: 2.3.3
     transitivePeerDependencies:
       - bufferutil

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,7 +7,7 @@ catalogs:
   core-common:
     drizzle-orm: ^0.44.6
     superjson: ^2.2.2
-    "@cloudflare/workers-types": ^4.20260129.0
+    '@cloudflare/workers-types': ^4.20260129.0
   dev-common:
     drizzle-kit: ^0.31.4
   validators:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,6 +7,7 @@ catalogs:
   core-common:
     drizzle-orm: ^0.44.6
     superjson: ^2.2.2
+    "@cloudflare/workers-types": ^4.20260129.0
   dev-common:
     drizzle-kit: ^0.31.4
   validators:

--- a/sample_integrations/counter/_shared/src/db/schema.ts
+++ b/sample_integrations/counter/_shared/src/db/schema.ts
@@ -1,6 +1,6 @@
 import { integer, sqliteTable } from 'drizzle-orm/sqlite-core'
 
-export const counter = sqliteTable('counter', () => ({
+export const counter = sqliteTable('counter', {
 	id: integer().primaryKey().notNull().default(0),
 	value: integer().notNull()
-}))
+})

--- a/sample_integrations/counter/_shared/src/db/schema.ts
+++ b/sample_integrations/counter/_shared/src/db/schema.ts
@@ -1,6 +1,6 @@
 import { integer, sqliteTable } from 'drizzle-orm/sqlite-core'
 
-export const counter = sqliteTable('counter', {
+export const counter = sqliteTable('counter', () => ({
 	id: integer().primaryKey().notNull().default(0),
 	value: integer().notNull()
-})
+}))


### PR DESCRIPTION
not particularly well-made but somewhat functional plugin to make the websockets Just Work with sveltekit when using service bindings instead of the (more stable? but more limited) approach with two separate subdomains

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a Vite plugin for SvelteKit enabling WebSocket support on Cloudflare Workers with optional verbose logging for debugging.

* **Documentation**
  * Added comprehensive documentation covering plugin installation, configuration, and usage examples.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->