### PR TITLE
default export for `vite-plugin-sveltekit-cf-websockets`

### DIFF
--- a/.changeset/young-ducks-brake.md
+++ b/.changeset/young-ducks-brake.md
@@ -1,0 +1,5 @@
+---
+'vite-plugin-sveltekit-cf-websockets': minor
+---
+
+Use a default export instead of named export

--- a/extras/vite-plugin-sveltekit-cf-websockets/src/index.ts
+++ b/extras/vite-plugin-sveltekit-cf-websockets/src/index.ts
@@ -569,7 +569,9 @@ export interface PluginOptions {
  * through SvelteKit's request handling pipeline, preserving the Response
  * object (including any `webSocket` property from Cloudflare-style handlers).
  */
-export function svelteKitWebSockets(options: PluginOptions = {}): Plugin {
+export default function svelteKitWebSockets(
+	options: PluginOptions = {}
+): Plugin {
 	const { verbose = false } = options
 
 	return {


### PR DESCRIPTION
This is a little bit more common for Vite plugins. Worked the way before but I will bikeshed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Breaking Changes**
  * The module export format has been updated to use a default export instead of a named export. Update your import statements accordingly when upgrading to this version.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->